### PR TITLE
fix clone logic when instance is set

### DIFF
--- a/plugins/backstage-highlights-plugin/src/components/GitInfoCloneField.tsx
+++ b/plugins/backstage-highlights-plugin/src/components/GitInfoCloneField.tsx
@@ -18,7 +18,7 @@ import React, { useState }  from 'react';
 import { CopyTextButton, LinkButton } from '@backstage/core-components';
 import { Dialog, DialogContent, TextField } from '@material-ui/core';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { GITHUB_ANNOTATION_PROJECT_SLUG, GITLAB_ANNOTATION_PROJECT_SLUG } from '../util';
+import { GITHUB_ANNOTATION_PROJECT_SLUG, GITLAB_ANNOTATION_PROJECT_SLUG, GITLAB_ANNOTATION_INSTANCE } from '../util';
 import { Alert } from '@material-ui/lab';
 
 const GitInfoCloneDialog = () => {
@@ -26,15 +26,17 @@ const GitInfoCloneDialog = () => {
 
     const githubAnnotation = entity.metadata.annotations?.[GITHUB_ANNOTATION_PROJECT_SLUG];
     const gitlabAnnotation = entity.metadata.annotations?.[GITLAB_ANNOTATION_PROJECT_SLUG];
+    const gitlabInstance = entity.metadata.annotations?.[GITLAB_ANNOTATION_INSTANCE] ?? 'gitlab.com';
+
 
     let cloneUrl: string | undefined;
-    
+
     if (githubAnnotation) {
-        cloneUrl = `https://github.com/${githubAnnotation}.git`;
+      cloneUrl = `https://github.com/${githubAnnotation}.git`;
+    } else if (gitlabAnnotation) {
+      cloneUrl = `https://${gitlabInstance}/${gitlabAnnotation}.git`;
     }
-    if (gitlabAnnotation) {
-        cloneUrl = `https://gitlab.com/${gitlabAnnotation}.git`;
-    }
+
     if (cloneUrl) {
         return (
             <>
@@ -92,4 +94,3 @@ export const GitInfoCloneField = () => {
         </>
     );
 };
-  

--- a/plugins/backstage-highlights-plugin/src/components/GitInfoCloneField.tsx
+++ b/plugins/backstage-highlights-plugin/src/components/GitInfoCloneField.tsx
@@ -32,9 +32,10 @@ const GitInfoCloneDialog = () => {
     let cloneUrl: string | undefined;
 
     if (githubAnnotation) {
-      cloneUrl = `https://github.com/${githubAnnotation}.git`;
-    } else if (gitlabAnnotation) {
-      cloneUrl = `https://${gitlabInstance}/${gitlabAnnotation}.git`;
+        cloneUrl = `https://github.com/${githubAnnotation}.git`;
+    }
+    if (gitlabAnnotation) {
+        cloneUrl = `https://${gitlabInstance}/${gitlabAnnotation}.git`;
     }
 
     if (cloneUrl) {

--- a/plugins/backstage-highlights-plugin/src/util/constants.ts
+++ b/plugins/backstage-highlights-plugin/src/util/constants.ts
@@ -20,6 +20,7 @@ import { EHighlightFields } from "./types";
 export const GITHUB_ANNOTATION_PROJECT_SLUG = 'github.com/project-slug';
 /** @public */
 export const GITLAB_ANNOTATION_PROJECT_SLUG = 'gitlab.com/project-slug';
+export const GITLAB_ANNOTATION_INSTANCE = 'gitlab.com/instance';
 
 export const DefaultGitInfoFields: EHighlightFields[] = [
     EHighlightFields.latest_tag,


### PR DESCRIPTION
changed logic to be: if `gitlab.com/instance` is present then set it, if not then go with hardcode gitlab.com.
closes https://github.com/RSC-Labs/backstage-highlights-plugin/issues/5 